### PR TITLE
feat: add engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,16 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
+        "cron": "^3.1.7",
         "dockerode": "^4.0.2",
         "env-paths": "^3.0.0",
         "figlet": "^1.7.0",
         "ora": "^8.0.1",
         "pino": "^9.2.0",
         "prettyjson": "^1.2.5"
+      },
+      "bin": {
+        "bitbrew": "dist/bin/bitbrew.js"
       },
       "devDependencies": {
         "@types/dockerode": "^3.3.29",
@@ -779,6 +783,11 @@
       "integrity": "sha512-G22AUvy4Tl95XLE7jmUM8s8mKcoz+Hr+Xm9W90gJsppJq9f9tHvOGkrpn4gRX0q/cLtBdNkWtWCKDg2UDZoZvQ==",
       "dev": true
     },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
+    },
     "node_modules/@types/node": {
       "version": "20.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
@@ -1154,6 +1163,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cron": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.7.tgz",
+      "integrity": "sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1606,6 +1624,14 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -3080,6 +3106,11 @@
       "integrity": "sha512-G22AUvy4Tl95XLE7jmUM8s8mKcoz+Hr+Xm9W90gJsppJq9f9tHvOGkrpn4gRX0q/cLtBdNkWtWCKDg2UDZoZvQ==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA=="
+    },
     "@types/node": {
       "version": "20.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
@@ -3344,6 +3375,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cron": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.1.7.tgz",
+      "integrity": "sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==",
+      "requires": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.4.0"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -3648,6 +3688,11 @@
       "requires": {
         "get-func-name": "^2.0.1"
       }
+    },
+    "luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
     },
     "magic-string": {
       "version": "0.30.10",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "bitbrew",
-  "version": "1.0.0",
+  "version": "0.1.0-alpha.1",
   "description": "",
   "main": "index.js",
+  "bin": {
+    "bitbrew": "dist/bin/bitbrew.js"
+  },
   "scripts": {
     "start": "ts-node src/index.ts",
     "test": "vitest",
@@ -15,6 +18,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "cron": "^3.1.7",
     "dockerode": "^4.0.2",
     "env-paths": "^3.0.0",
     "figlet": "^1.7.0",

--- a/src/actions/brewAction.ts
+++ b/src/actions/brewAction.ts
@@ -3,8 +3,9 @@ import { getWalletController } from "../controllers/walletController.js";
 import figlet from "figlet";
 import chalk from "chalk";
 import { clilog } from "../utils/cliLogger.js";
+import { Engine } from "../engine/engine.js";
 
-export default async function brewAction(options: { nodes: number }) {
+export default async function brewAction(options: { nodes: number, engine: boolean }) {
     console.log(chalk.hex('F2A900')(figlet.textSync('BitBrew',{
       font: 'Doom',
       horizontalLayout: 'default',
@@ -17,7 +18,12 @@ export default async function brewAction(options: { nodes: number }) {
       await networkController.createPaths();
       await networkController.initializeNodes(options.nodes);
       await networkController.startNetwork();
-      await walletController.createWallets(options.nodes);
+      if(options.engine) {
+        await networkController.connectAllNodes();
+        const wallets = await walletController.createWallets(options.nodes);
+        const engine = new Engine(wallets)
+        engine.run();
+      }
     } catch (err) {
         clilog.stopSpinner(false);
         if(err instanceof Error)

--- a/src/bin/bitbrew.ts
+++ b/src/bin/bitbrew.ts
@@ -2,6 +2,8 @@
 import { Command } from 'commander';
 import figlet from 'figlet';
 import chalk from 'chalk';
+const packageJson = await import('../../package.json', { assert: { type: 'json' } });
+
 import { BrewCommand, 
         CleanCommand, 
         ConnectCommand,
@@ -18,9 +20,8 @@ import { BrewCommand,
       } from '../commands/index.js';
 
 const program: Command = new Command();
-
 program
-  .version('0.1.0')
+  .version(JSON.stringify(packageJson['default'].version))
   .description('BitBrew: Craft your own Bitcoin test networks with ease')
   .action(() => {
     program.outputHelp();

--- a/src/commands/brewCommand.ts
+++ b/src/commands/brewCommand.ts
@@ -5,6 +5,7 @@ export const BrewCommand = new Command()
     .name('brew')
     .description('Brew your own Bitcoin test network')
     .option('-n, --nodes <number>', 'Number of nodes to brew', '2')
+    .option('-e, --engine', 'Run the engine')
     .action(async (options) => {
-        brewAction({ nodes: options.nodes });
+        brewAction({ nodes: options.nodes, engine: options.engine });
     })

--- a/src/controllers/stateController.ts
+++ b/src/controllers/stateController.ts
@@ -96,10 +96,13 @@ export class StateController{
         return [];
     }
 
-    public saveWallet(name: string, node: string) {
+    public saveWallet(name: string, node: string): Promise<void> {
         const wallets = this.loadWallets();
         wallets.push({ name, node });
-        fs.writeFileSync(this.getWalletsFile(), JSON.stringify(wallets, null, 2));
+        return new Promise((resolve, reject) => {
+            fs.writeFileSync(this.getWalletsFile(), JSON.stringify(wallets, null, 2));
+        resolve();
+        });
     }
 
     public deleteState() {

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -25,7 +25,7 @@ export interface IStateController {
     getNodeDataDir(nodeName: string): string;
     loadWallets(): Wallet[];
     getWalletsDir(): string;
-    saveWallet(name: string, node: string): void;
+    saveWallet(name: string, node: string): Promise<void>;
     removeNode(nodeName: string): void;
     deleteAllData(): void;
     setNodeStatus(nodeName: string, status: NodeConfig['status']): void;
@@ -34,7 +34,7 @@ export interface IStateController {
 export interface IDockerController {
     createNetwork(name: string): Promise<void>;
     removeNetwork(name: string): Promise<void>;
-    execCommand(containerName: string, command: string): void;
+    execCommand(containerName: string, command: string): Promise<string>;
     getExecOutput(containerName: string, command: string): Promise<string>;
     attachToContainer(containerName: string): void;
     getContainer(containerName: string): any;

--- a/src/controllers/walletController.ts
+++ b/src/controllers/walletController.ts
@@ -18,11 +18,11 @@ class WalletController {
         return this.stateController.loadWallets();
     }
 
-    async createWallet(name: string, node: string) {
+    async createWallet(name: string, node: string): Promise<string>{
         clilog.startSpinner(`Creating wallet ${name} on node ${node}...`);
         try{
-        this.docker.getExecOutput(node, `bitcoin-cli createwallet ${name}`);
-        this.stateController.saveWallet(name, node);
+        await this.docker.getExecOutput(node, `bitcoin-cli createwallet ${name}`);
+        await this.stateController.saveWallet(name, node);
         } catch (error) {
             if (error instanceof Error) {
                 throw new Error(error.message);
@@ -31,14 +31,18 @@ class WalletController {
             }
         }
         clilog.stopSpinner(true, `Wallet ${name} created`);
+        return name;
     }
 
-    async createWallets(nodes: number) {
+    async createWallets(nodes: number): Promise<string[]> {
+        const wallets: string[] = [];
         for (let i = 0; i < nodes; i++) {
             const name = `wallet${i}`;
             const node = `node${i}`;
             await this.createWallet(name, node);
+            wallets.push(name);
         }
+        return wallets;
     }
 
     async listWallets() {
@@ -127,7 +131,7 @@ class WalletController {
         }
         try {
         const address = await this.getAddress(walletName);
-        this.docker.execCommand(wallet.node, `bitcoin-cli generatetoaddress ${blocks} ${address}`);
+        await this.docker.execCommand(wallet.node, `bitcoin-cli generatetoaddress ${blocks} ${address}`);
         } catch (error) {
             if (error instanceof Error) {
                 throw new Error(error.message);

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,0 +1,52 @@
+import { CronJob } from "cron";
+import { getWalletController } from "../controllers/walletController.js";
+
+export class Engine {
+
+    private wallets: string[];
+    private miner: string;
+    //pick the first wallet as the miner
+    constructor(wallets: string[]) {
+        this.wallets = wallets;
+        this.miner = wallets[0]!;
+    }
+
+    private async mineInitialBlocks() {
+        const walletController = getWalletController();
+        await walletController.mineBlocks(this.miner, 101);
+        console.log(`Mined 101 blocks to ${this.miner}`);
+    }
+
+    private async distributeMinedCoins() {
+        const walletController = getWalletController();
+        for (let i = 1; i < this.wallets.length; i++) {
+            await walletController.transferBitcoin(this.miner, this.wallets[i]!, 50/this.wallets.length);
+        }
+        console.log("Distributed coins");
+    }
+
+    private async mineBlock(miner: string) {
+        const walletController = getWalletController();
+        await walletController.mineBlocks(miner, 1);
+        console.log("Mined a block");
+        await this.distributeMinedCoins();
+    }
+
+    private async createRandomTransaction(wallets: string[]) {
+        // choose random amount between 0.1 and 2
+        const amount = Number((Math.random() * (2 - 0.1) + 0.1).toFixed(3));
+        const walletController = getWalletController();
+        const sender = wallets[Math.floor(Math.random() * wallets.length)];
+        const receiver = wallets[Math.floor(Math.random() * wallets.length)];
+        await walletController.transferBitcoin(sender!, receiver!, amount);
+        console.log(`Transferred ${amount} BTC from ${sender} to ${receiver}`);
+    }
+
+    public async run() {
+        await this.mineInitialBlocks();
+        await this.distributeMinedCoins();
+        this.mineBlock(this.miner);
+        new CronJob('*/2 * * * * *', () => this.createRandomTransaction(this.wallets)).start();
+        new CronJob('*/30 * * * * *', () => this.mineBlock(this.miner)).start();
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Engine:
- add `node-cron`
- start engine with `brew -e` flag
- mine 101 blocks into first wallet
- distribute the reward
- create a transaction every 2 second
- mine a block every 30 second

Other changes:
- Add bitbrew to under bin in package.json
- import the version from package.json