### PR TITLE
docs: add examples and initial documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 dist/
 
 venv/
+site/
 
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 
 venv/
+
+.cache/

--- a/.npmignore
+++ b/.npmignore
@@ -20,7 +20,10 @@ docker/
 
 # Documentation
 docs/
+mkdocs.yml
+requirements.txt
 
 # Development files
 *.log
 .DS_Store
+venv/

--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@ docs/
 mkdocs.yml
 requirements.txt
 .cache/
+site/
 
 # Development files
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,7 @@ docker/
 docs/
 mkdocs.yml
 requirements.txt
+.cache/
 
 # Development files
 *.log

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -1,0 +1,1 @@
+# Basic Usage

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -1,1 +1,141 @@
-# Basic Usage
+# Creating a Network and Performing Transactions
+
+This guide will walk you through a basic example of using BitBrew to create a Bitcoin test network, set up wallets, mine some blocks, and perform a transaction. By following this example, you'll gain hands-on experience with the core features of BitBrew.
+
+## Step 1: Create a Network
+
+First, let's create a simple network with two nodes.
+
+```bash
+bitbrew brew
+```
+
+This command creates and starts a network with two nodes: `node0` and `node1`.
+
+Verify the network creation:
+
+```bash
+bitbrew ls
+```
+
+You should see output similar to:
+
+```bash
+┌─────────┬─────────┬───────────┬───────┬──────────┐
+│ (index) │  name   │  status   │ port  │ RPC port │
+├─────────┼─────────┼───────────┼───────┼──────────┤
+│    0    │ 'node0' │ 'running' │ 20443 │  21443   │
+│    1    │ 'node1' │ 'running' │ 20444 │  21444   │
+└─────────┴─────────┴───────────┴───────┴──────────┘
+```
+
+## Step 2: Connect the Nodes
+
+Now, let's connect the two nodes:
+
+```bash
+bitbrew connect node0 node1
+```
+
+This establishes a connection between `node0` and `node1`.
+
+## Step 3: Create Wallets
+
+We'll create two wallets, one for each node:
+
+```bash
+bitbrew wallet create alice node0
+bitbrew wallet create bob node1
+```
+
+Verify the wallet creation:
+
+```bash
+bitbrew wallet ls
+```
+
+You should see:
+
+```bash
+┌─────────┬─────────┬─────────┐
+│ (index) │  name   │  node   │
+├─────────┼─────────┼─────────┤
+│    0    │ 'alice' │ 'node0' │
+│    1    │  'bob'  │ 'node1' │
+└─────────┴─────────┴─────────┘
+```
+
+## Step 4: Mine Some Blocks
+
+To get some coins in Alice's wallet, we'll mine 101 blocks:
+
+```bash
+bitbrew mine alice 101
+```
+
+This mines 101 blocks, with the block rewards going to Alice's wallet. We mine 101 blocks because the coinbase transactions (which create new coins) require 100 confirmations before they can be spent.
+
+## Step 5: Check Balances
+
+Let's check the balance in Alice's wallet:
+
+```bash
+bitbrew wallet balance alice
+```
+
+You should see a balance of 50 BTC for each block mined (minus the first block), so approximately 5000 BTC.
+
+Bob's wallet should still have 0 BTC:
+
+```bash
+bitbrew wallet balance bob
+```
+
+## Step 6: Perform a Transaction
+
+Now, let's send some Bitcoin from Alice to Bob:
+
+```bash
+bitbrew send alice bob 10
+```
+
+This sends 10 BTC from Alice's wallet to Bob's wallet.
+
+## Step 7: Verify the Transaction
+
+Check the balances again:
+
+```bash
+bitbrew wallet balance alice
+bitbrew wallet balance bob
+```
+
+You should see that Bob now has 10 BTC, and Alice's balance has decreased by slightly more than 10 BTC (the extra amount is the transaction fee).
+
+## Step 8: Mine Another Block
+
+To ensure the transaction is confirmed, let's mine another block:
+
+```bash
+bitbrew mine alice 1
+```
+
+## Conclusion
+
+Congratulations! You've successfully:
+
+1. Created a Bitcoin test network
+2. Connected nodes in the network
+3. Created wallets
+4. Mined blocks to generate coins
+5. Performed a transaction between wallets
+
+This basic example demonstrates the core functionality of BitBrew. From here, you can explore more advanced features like adding more nodes, creating complex network topologies, or simulating various Bitcoin network scenarios.
+
+Remember to clean up your test network when you're done:
+
+```bash
+bitbrew clean
+```
+
+This removes all nodes and resets your BitBrew environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,1 @@
+# Getting Started

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,7 +150,6 @@ Congratulations! You've set up a Bitcoin test network, created wallets, mined bl
 
 - Explore more commands with `bitbrew --help`
 - Check out the [User Guide](user-guide/basic-concepts.md) for detailed information on each feature
-- Try our [Examples](examples/multi-node-network.md) for more complex scenarios, like setting up multi-node networks or simulating specific network conditions
 - Join our community forums or GitHub discussions to share your experiences and get help
 
 Remember, BitBrew allows you to experiment freely without affecting the real Bitcoin network. Happy brewing, and enjoy exploring the world of Bitcoin development!

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,1 +1,156 @@
-# Getting Started
+# Getting Started with BitBrew
+
+Welcome to BitBrew! This comprehensive guide will walk you through setting up BitBrew and creating your first Bitcoin test network.
+
+## Prerequisites
+
+Before diving into BitBrew, let's ensure you have the necessary tools installed.
+
+### Docker
+
+BitBrew leverages Docker to create isolated environments for Bitcoin nodes. This approach ensures consistency across different systems and simplifies the setup process.
+
+- Download Docker from [docker.com](https://www.docker.com/products/docker-desktop)
+- Installation steps vary by operating system:
+  - Windows and Mac: Use the Docker Desktop installer
+  - Linux: Follow the appropriate installation guide for your distribution
+- After installation, open a terminal/command prompt and verify Docker is working:
+  ```
+  docker --version
+  docker run hello-world
+  ```
+
+If both commands execute without errors, Docker is set up correctly.
+
+### Node.js
+
+BitBrew is built on Node.js, allowing it to run on various platforms.
+
+- Download Node.js (version 18 or higher) from [nodejs.org](https://nodejs.org/en/download/)
+- Choose the appropriate installer for your operating system
+- After installation, verify by opening a terminal/command prompt and running:
+  ```
+  node --version
+  npm --version
+  ```
+
+Both commands should return version numbers without any errors.
+
+## Installation
+
+With the prerequisites in place, you're ready to install BitBrew.
+
+```bash
+npm install -g bitbrew
+```
+
+This command installs BitBrew globally on your system, making the `bitbrew` command available from any directory.
+
+Verify the installation:
+
+```bash
+bitbrew --version
+```
+
+If you see a version number, BitBrew is installed correctly.
+
+## Quick Start Guide
+
+Now, let's create your first Bitcoin test network and explore BitBrew's core features.
+
+### 1. Brew Your Network
+
+The `brew` command is your starting point with BitBrew. It sets up a basic network with two nodes.
+
+```bash
+bitbrew brew
+```
+
+This command:
+- Creates two Docker containers, each running a Bitcoin Core node in regtest mode
+- Sets up the necessary configuration for each node
+- Starts the nodes
+
+### 2. List Your Nodes
+
+The `ls` command gives you an overview of your network.
+
+```bash
+bitbrew ls
+```
+
+You'll see a table with details about each node:
+- Name: The identifier for each node
+- Status: Whether the node is running or stopped
+- Port: The network port the node is using
+- RPC port: The port used for Remote Procedure Calls (RPC) to interact with the node
+
+### 3. Connect the Nodes
+
+In a real Bitcoin network, nodes discover and connect to each other automatically. In our controlled environment, we manually connect them.
+
+```bash
+bitbrew connect node0 node1
+```
+
+This command establishes a connection from `node0` to `node1`, allowing them to exchange information.
+
+### 4. Create Wallets
+
+Wallets are essential for managing funds in Bitcoin. Let's create two wallets:
+
+```bash
+bitbrew wallet create alice node0
+bitbrew wallet create bob node1
+```
+
+These commands create wallets named "alice" and "bob" on `node0` and `node1` respectively. In a test environment, it's common to use descriptive names like this for clarity.
+
+### 5. Mine Some Blocks
+
+In Bitcoin, new coins are created through mining. Let's mine some blocks to generate coins:
+
+```bash
+bitbrew mine alice 101
+```
+
+This command:
+- Mines 101 blocks
+- Sends the block rewards to the "alice" wallet
+- We mine 101 blocks because the coinbase transaction (which creates new coins) requires 100 confirmations before it can be spent
+
+### 6. Send Funds
+
+Now that we have some coins, let's perform a transaction:
+
+```bash
+bitbrew send alice bob 10
+```
+
+This command sends 10 BTC from Alice's wallet to Bob's wallet. In the background, BitBrew:
+- Creates a transaction
+- Signs it with Alice's wallet
+- Broadcasts it to the network
+- Mines a new block to confirm the transaction
+
+### 7. Check Balances
+
+To verify the transaction, let's check both wallets:
+
+```bash
+bitbrew wallet balance alice
+bitbrew wallet balance bob
+```
+
+You should see that Bob's balance has increased by 10 BTC, while Alice's has decreased by slightly more than 10 BTC (the extra amount is the transaction fee).
+
+## Next Steps
+
+Congratulations! You've set up a Bitcoin test network, created wallets, mined blocks, and performed a transaction. Here's how you can dive deeper:
+
+- Explore more commands with `bitbrew --help`
+- Check out the [User Guide](user-guide/basic-concepts.md) for detailed information on each feature
+- Try our [Examples](examples/multi-node-network.md) for more complex scenarios, like setting up multi-node networks or simulating specific network conditions
+- Join our community forums or GitHub discussions to share your experiences and get help
+
+Remember, BitBrew allows you to experiment freely without affecting the real Bitcoin network. Happy brewing, and enjoy exploring the world of Bitcoin development!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Introduction
+
+```bash
+$ npm install -g bitbrew
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,8 +53,8 @@ This simple command installs BitBrew and creates your first test network with tw
 
 To dive deeper into BitBrew:
 
-1. Check out the [Installation](getting-started/installation.md) guide for detailed setup instructions.
-2. Learn how to use BitBrew with our [Quick Start](getting-started/quick-start.md) tutorial.
-3. Explore advanced features in the [User Guide](user-guide/basic-usage.md).
+1. Check out [Getting Started](getting-started.md) for detailed setup instructions.
+2. Have a look at all the commands at [Command Reference](user-guide/command-reference.md)
+3. Look at an [example](examples/basic-usage.md).
 
 Join us in brewing the future of Bitcoin development, where reliable and controllable test environments are just a command away!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,60 @@
 # Introduction
 
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/08a57f5a-099a-48c5-b37b-6c27ecc7350b" width="250" alt="BitBrew Logo">
+</p>
+
+BitBrew is a powerful CLI tool designed to revolutionize Bitcoin test network interactions. By providing an intuitive interface to the Bitcoin Core RPC API and leveraging regtest mode, BitBrew creates isolated networks ideal for testing, development, and educational purposes.
+
+!!! warning
+    BitBrew is currently in the alpha phase of development. While functional, it may contain bugs or undergo significant changes.
+
+## The Challenge with Traditional Testnets
+
+Bitcoin developers and testers often face significant hurdles when working with traditional testnets. These public networks can be unpredictable and unreliable, with constantly changing network conditions. Developers have limited control over crucial aspects like block times and mining, while competition for shared resources can hinder efficient development and testing.
+
+Recent events have further highlighted the volatility of public testnets. For instance, a [griefing attack on Bitcoin's testnet](https://www.theblock.co/post/291519/bitcoin-testnet-griefing-attack-generates-three-years-worth-of-blocks-in-one-week-frustrating-developers) generated three years' worth of blocks in just one week, causing significant disruptions for developers.
+
+Setting up a private testnet manually is often a complex, time-consuming, and error-prone process. These challenges can significantly slow down development, complicate testing processes, and create barriers for newcomers to Bitcoin development.
+
+## BitBrew: Crafting Reliable Test Environments
+
+BitBrew addresses these challenges head-on by allowing you to brew your own private Bitcoin test networks. With BitBrew, you can:
+
+- Create isolated environments free from external interference
+- Maintain full control over block generation, mining, and network conditions
+- Spin up a fully functional test network with a single command
+- Ensure a stable, predictable environment for repeatable tests and experiments
+
+## Key Features and Benefits
+
+BitBrew stands out for its simplicity and power, offering a streamlined way to work with Bitcoin networks:
+
+- **Easy Network Creation**: Brew your own Bitcoin test network with a single command.
+- **Comprehensive Node Management**: Effortlessly add, remove, start, and stop nodes in your network.
+- **Wallet Operations**: Create wallets, mine blocks, and transfer funds between wallets with ease.
+- **Network Visualization**: Quickly list and inspect your network nodes and their connections.
+- **Direct Node Interaction**: Attach to nodes or execute Bitcoin Core commands directly from the CLI.
+
+By choosing BitBrew, you're opting for reliability over unpredictable testnet behavior, simplified setup over complex configurations, and a controlled environment perfect for learning and development. The Docker integration ensures consistent and isolated environments, making BitBrew an ideal tool for both seasoned developers and newcomers to Bitcoin development.
+
+## Quick Start
+
+Get started with BitBrew in minutes:
+
 ```bash
-$ npm install -g bitbrew
+npm install -g bitbrew
+bitbrew brew
 ```
+
+This simple command installs BitBrew and creates your first test network with two regtest nodes, giving you immediate access to a controlled Bitcoin testing environment.
+
+## Next Steps
+
+To dive deeper into BitBrew:
+
+1. Check out the [Installation](getting-started/installation.md) guide for detailed setup instructions.
+2. Learn how to use BitBrew with our [Quick Start](getting-started/quick-start.md) tutorial.
+3. Explore advanced features in the [User Guide](user-guide/basic-usage.md).
+
+Join us in brewing the future of Bitcoin development, where reliable and controllable test environments are just a command away!

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,7 @@ This is a high-level roadmap for the BitBrew project. It outlines the key featur
 
 - Develop a plugin system/architecture for extensibility
 - Implement advanced features like custom signet networks and support for other Bitcoin implementations
+- Simulate network latency
 - Create an API for programmatic interaction with the network
 - Implement network visualization
 - Add support for custom Docker images

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,52 @@
+# Roadmap
+
+This is a high-level roadmap for the BitBrew project. It outlines the key features and milestones planned for the project. The roadmap is subject to change based on feedback and contributions from the community.
+
+**Last release**: 0.1.0-alpha
+
+## 0.1.0
+
+- [ ] Add debug logging and improve error handling
+- [ ] Fix bugs from initial release and improve overall stability
+- [ ] Improve help messages
+- [ ] Use `esbuild` for more compact and faster builds
+- [ ] Update documentation and add examples
+
+## 0.2.0
+
+- [ ] **Optimize and finalize the engine feature**
+- [ ] Implement node renaming functionality
+- [ ] Add support for creating multiple nodes with a single command (e.g., `bitbrew add -n 3`)
+- [ ] Allow users to edit `bitcoin.conf` files for individual nodes
+- [ ] Implement node restart functionality
+- [ ] Other minor improvements and bug fixes
+
+## Long-term Vision (1.0.0 and beyond)
+
+- Develop a plugin system/architecture for extensibility
+- Implement advanced features like custom signet networks and support for other Bitcoin implementations
+- Create an API for programmatic interaction with the network
+- Implement network visualization
+- Add support for custom Docker images
+- Develop snapshot and restore functionality for network states
+- Implement time manipulation features (fast-forward, pause)
+- Implement scalability solutions to span across multiple hosts
+
+## Milestones
+
+- [x] 0.1.0-alpha
+  - [x] Initial project structure and core functionality
+  - [x] Basic CLI interface with essential commands
+  - [x] Docker integration for node management
+  - [x] Wallet creation and management
+  - [x] Basic transaction and mining capabilities
+
+
+## Key Features to develop
+
+- Improved error handling and logging
+- Enhanced network management
+- Advanced wallet operations
+- Integration with external tools (explorers, monitoring)
+- Snapshot and restore capabilities
+- Time manipulation for testing scenarios

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,11 +6,11 @@ This is a high-level roadmap for the BitBrew project. It outlines the key featur
 
 ## 0.1.0
 
+- [x] Update documentation and add examples
 - [ ] Add debug logging and improve error handling
 - [ ] Fix bugs from initial release and improve overall stability
 - [ ] Improve help messages
 - [ ] Use `esbuild` for more compact and faster builds
-- [ ] Update documentation and add examples
 
 ## 0.2.0
 
@@ -31,6 +31,7 @@ This is a high-level roadmap for the BitBrew project. It outlines the key featur
 - Develop snapshot and restore functionality for network states
 - Implement time manipulation features (fast-forward, pause)
 - Implement scalability solutions to span across multiple hosts
+- Adding detailed analytics and monitoring capabilities using tools like Prometheus and Grafana
 
 ## Milestones
 

--- a/docs/user-guide/basic-concepts.md
+++ b/docs/user-guide/basic-concepts.md
@@ -1,0 +1,94 @@
+# Basic Concepts
+
+Welcome to the BitBrew Basic Concepts guide. This document will introduce you to the fundamental components and ideas behind BitBrew and its Bitcoin test networks. Understanding these concepts will help you make the most of BitBrew's features.
+
+## Nodes
+
+In the context of BitBrew, a node represents a Bitcoin Core instance running in regtest mode. Each node is an independent participant in your test network, capable of mining blocks, validating transactions, and maintaining a copy of the blockchain. BitBrew creates and manages these nodes using Docker containers, providing a consistent and isolated environment for each node.
+
+Key characteristics of nodes in BitBrew:
+
+- Independent Bitcoin Core instances
+- Run in regtest mode
+- Managed via Docker containers
+- Identified by simple names (e.g., `node0`, `node1`)
+
+Common node operations:
+
+1. Add a node: `bitbrew add <node_name>`
+2. Remove a node: `bitbrew remove <node_name>`
+3. Start a node: `bitbrew start <node_name>`
+4. Stop a node: `bitbrew stop <node_name>`
+5. List all nodes: `bitbrew ls`
+
+## Wallets
+
+Wallets in BitBrew are Bitcoin wallets associated with specific nodes. They serve as the interface for managing, sending, and receiving Bitcoin within your test network. Each wallet is tied to a specific node, allowing you to simulate different participants in your Bitcoin network.
+
+Key points about wallets:
+
+- Associated with specific nodes
+- Manage private keys and addresses
+- Can have descriptive names (e.g., "alice", "bob")
+- Simulate different network participants
+
+Wallet operations:
+
+1. Create a wallet: `bitbrew wallet create <wallet_name> <node_name>`
+2. List wallets: `bitbrew wallet ls`
+3. Check balance: `bitbrew wallet balance <wallet_name>`
+4. Send funds: `bitbrew send <from_wallet> <to_wallet> <amount>`
+
+## Network
+
+The network in BitBrew refers to the collection of interconnected nodes that form your private Bitcoin test environment. This network is completely isolated from the public Bitcoin network, giving you full control over network conditions, block generation, and connections.
+
+Network features:
+
+- Isolated from the public Bitcoin network
+- Fully controllable environment
+- Customizable topology and conditions
+
+Main network operations:
+
+1. Create a network: `bitbrew brew`
+2. Connect nodes: `bitbrew connect <source_node> <target_node>`
+3. Mine blocks: `bitbrew mine <wallet_name> <number_of_blocks>`
+
+## Regtest Mode
+
+BitBrew uses Bitcoin Core's regression test mode (regtest). This mode is specifically designed for testing and development purposes, offering features that make it ideal for creating controlled test environments.
+
+Key features of regtest mode:
+
+- Instant block generation on-demand
+- Easy blockchain reset (stop and restart network)
+- Completely controlled environment
+- No influence from external factors
+
+## Docker Integration
+
+BitBrew leverages Docker to create isolated environments for each node. This integration provides several key benefits for testing and development.
+
+Benefits of Docker integration:
+
+1. Consistency across different systems
+2. Easy setup and teardown of nodes
+3. Isolation between nodes and from the host system
+4. Realistic simulation of network environments
+
+## Understanding BitBrew's Workflow
+
+The typical BitBrew workflow follows these steps:
+
+1. Create a network (`brew`): Sets up Docker containers for nodes.
+2. Connect nodes: Establishes connections between nodes in your network.
+3. Create wallets: Allows you to manage funds within nodes.
+4. Mine blocks: Generates new blocks and Bitcoin in your test network.
+5. Perform transactions: Send Bitcoin between wallets to simulate activity.
+
+This workflow allows you to create complex scenarios and test various aspects of Bitcoin applications in a controlled, realistic environment.
+
+By understanding these basic concepts, you'll be well-equipped to use BitBrew effectively for your Bitcoin development and testing needs. As you become more familiar with these components, you'll be able to create increasingly complex scenarios and thoroughly test various aspects of Bitcoin applications.
+
+For more detailed information on each concept and associated commands, please refer to the respective sections in the User Guide.

--- a/docs/user-guide/command-reference.md
+++ b/docs/user-guide/command-reference.md
@@ -1,0 +1,162 @@
+# BitBrew Command Reference
+
+This guide provides a comprehensive list of all available BitBrew commands, their syntax, options, and brief descriptions.
+
+## Network Management
+
+### `brew`
+
+Creates and starts a new Bitcoin test network.
+
+Syntax: `bitbrew brew [options]`
+
+Options:
+
+- `-n, --nodes <number>`: Number of nodes to create (default: 2)
+- `-e, --engine`: Start the BitBrew engine for automatic network activity
+
+Example: `bitbrew brew -n 3`
+
+### `connect`
+
+Connects nodes in the Bitcoin network.
+
+Syntax: `bitbrew connect [options] [source-node] [target-node...]`
+
+Options:
+
+- `-a, --all`: Connect all nodes in a round-robin fashion
+
+Example: `bitbrew connect node0 node1 node2`
+
+### `ls`
+
+Lists all nodes in your Bitcoin test network.
+
+Syntax: `bitbrew ls`
+
+### `start`
+
+Starts nodes in the Bitcoin network.
+
+Syntax: `bitbrew start [options] [node...]`
+
+Options:
+
+- `-a, --all`: Start all nodes
+
+Example: `bitbrew start node0 node1`
+
+### `stop`
+
+Stops nodes in your Bitcoin test network.
+
+Syntax: `bitbrew stop [options] [node...]`
+
+Options:
+
+- `-a, --all`: Stop all nodes
+
+Example: `bitbrew stop node0`
+
+### `add`
+
+Adds a new node to your Bitcoin test network.
+
+Syntax: `bitbrew add <name>`
+
+Example: `bitbrew add node3`
+
+### `remove`
+
+Removes nodes from your Bitcoin test network.
+
+Syntax: `bitbrew remove <node>`
+
+Example: `bitbrew remove node2`
+
+### `clean`
+
+Cleans up your Bitcoin test network, removing all nodes and associated data.
+
+Syntax: `bitbrew clean`
+
+## Node Interaction
+
+### `exec`
+
+Executes a command on a specific node.
+
+Syntax: `bitbrew exec <node> <command>`
+
+Example: `bitbrew exec node0 getblockchaininfo`
+
+### `attach`
+
+Attaches to a running node, allowing direct interaction.
+
+Syntax: `bitbrew attach <node>`
+
+Example: `bitbrew attach node1`
+
+## Wallet Operations
+
+### `wallet create`
+
+Creates a new wallet for a specified node.
+
+Syntax: `bitbrew wallet create <name> <node>`
+
+Example: `bitbrew wallet create alice node0`
+
+### `wallet ls`
+
+Lists all wallets in your Bitcoin test network.
+
+Syntax: `bitbrew wallet ls`
+
+### `wallet balance`
+
+Displays the balance of a specified wallet.
+
+Syntax: `bitbrew wallet balance <name>`
+
+Example: `bitbrew wallet balance alice`
+
+### `send`
+
+Transfers funds between wallets.
+
+Syntax: `bitbrew send <from> <to> <amount>`
+
+Example: `bitbrew send alice bob 10`
+
+## Mining
+
+### `mine`
+
+Mines a specified number of blocks, with rewards going to the specified wallet.
+
+Syntax: `bitbrew mine <wallet> [number]`
+
+Example: `bitbrew mine alice 10`
+
+## Miscellaneous
+
+### `--version`
+
+Displays the version of BitBrew.
+
+Syntax: `bitbrew --version`
+
+### `--help`
+
+Displays help information for BitBrew or a specific command.
+
+Syntax: `bitbrew --help [command]`
+
+Example: `bitbrew --help connect`
+
+---
+
+Remember that all commands should be prefixed with `bitbrew`. For more detailed information on each command and its usage, you can use the `--help` option with any command.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: BitBrew
 
 repo_url: https://github.com/rishkwal/bitbrew
 repo_name: rishkwal/bitbrew
+edit_uri: edit/main/docs/
 
 nav:
   - Introduction: index.md
@@ -37,6 +38,7 @@ theme:
     
   features:
       - navigation.footer
+      - content.action.edit
 
 extra:
   generator: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,63 @@
+site_name: BitBrew
+
+repo_url: https://github.com/rishkwal/bitbrew
+repo_name: rishkwal/bitbrew
+
+nav:
+  - Introduction: index.md
+  - Getting Started: getting-started.md
+  - Roadmap: roadmap.md
+  - Examples:
+    - Basic Usage: examples/basic-usage.md
+
+theme:
+  name: material
+  default_palette: slate
+  font:
+    text: 'Roboto'
+    code: 'Roboto Mono'
+  palette: 
+    - scheme: slate
+      primary: brown
+      accent: deep orange
+      text: white
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+    - scheme: default
+      primary: brown
+      accent: deep orange
+      background: white
+      text: black
+      code: brown
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+    
+  features:
+      - navigation.footer
+
+extra:
+  generator: false
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+      clickable_checkbox: false
+  - pymdownx.escapeall:
+      hardbreak: true
+      nbsp: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.mark
+  - pymdownx.tilde
+  - pymdownx.critic
+  - attr_list
+  - md_in_html
+  - admonition
+  - pymdownx.details

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,20 +3,27 @@ site_name: BitBrew
 repo_url: https://github.com/rishkwal/bitbrew
 repo_name: rishkwal/bitbrew
 edit_uri: edit/main/docs/
+site_url: https://rishkwal.github.io/bitbrew
+
+plugins:
+  - social
 
 nav:
   - Introduction: index.md
   - Getting Started: getting-started.md
+  - User Guide:
+    - Basic Concepts: user-guide/basic-concepts.md
+    - Command Reference: user-guide/command-reference.md
   - Roadmap: roadmap.md
   - Examples:
-    - Basic Usage: examples/basic-usage.md
+    - Basic Example: examples/basic-usage.md
 
 theme:
   name: material
   default_palette: slate
   font:
     text: 'Roboto'
-    code: 'Roboto Mono'
+    code: 'Menlo'
   palette: 
     - scheme: slate
       primary: brown
@@ -39,6 +46,7 @@ theme:
   features:
       - navigation.footer
       - content.action.edit
+      - content.code.copy
 
 extra:
   generator: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/rishkwal/bitbrew
 repo_name: rishkwal/bitbrew
 edit_uri: edit/main/docs/
 site_url: https://rishkwal.github.io/bitbrew
+site_description: A simple tool to craft private Bitcoin test networks
 
 plugins:
   - social

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.5.29


### PR DESCRIPTION
This PR does the following:

- add and configure `mkdocs`
- add `Introduction`, `Getting Started`, `User Guide`, `Roadmap` and `Examples` sections in the documentation